### PR TITLE
Add client-side Sentry logging

### DIFF
--- a/example_local.py
+++ b/example_local.py
@@ -62,3 +62,4 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 
 USING_RAVEN = False
 # RAVEN_DSN = '' # Get Raven DSN from Sentry
+# RAVEN_ENVIRONMENT = '' # One of: development, staging, or production.

--- a/settings.py
+++ b/settings.py
@@ -263,9 +263,15 @@ if local.HAS_STEAM_API_KEY:
     SOCIAL_AUTH_STEAM_API_KEY = local.STEAM_API_KEY
 
 if local.USING_RAVEN:
+    # These are kept in separate variables so that they can be easily accessed
+    # by the hacky `settings_value` template tag.
+    RAVEN_RELEASE = raven.fetch_git_sha(os.path.dirname(os.pardir))
+    RAVEN_ENVIRONMENT = local.RAVEN_ENVIRONMENT
+
     RAVEN_CONFIG = {
         'dsn': local.RAVEN_DSN,
+        'environment': RAVEN_ENVIRONMENT,
         # If you are using git, you can also automatically configure the
         # release based on the git info.
-        'release': raven.fetch_git_sha(os.path.dirname(os.pardir)),
+        'release': RAVEN_RELEASE,
     }


### PR DESCRIPTION
Adds/tweaks the config/settings params needed for client-side Raven to function.

Also adds `environment` to all Sentry reports.