### PR TITLE
Change tracker URL to root

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -7,7 +7,7 @@ import ajax_select.urls
 from tracker.views import logout
 
 urlpatterns = [
-    url(r'^tracker/', include(tracker.urls)),
+    url(r'^', include(tracker.urls)),
     url(r'^admin/lookups/', include(ajax_select.urls)),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^logout/', logout),


### PR DESCRIPTION
GDQ runs their tracker at /tracker, but we run ours at root on a
subdomain.